### PR TITLE
Update PHP version to 8.0+ and upgrade dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
 
     steps:
       - name: "Checkout"
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
 
     steps:
       - name: "Checkout"

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ test:
 	$(MAKE) fmt-check
 
 phpstan:
-	docker run -it --rm -v ${PWD}:/app -w /app php:7.4-cli-alpine php -d error_reporting=-1 -d memory_limit=-1 bin/phpstan --ansi analyse
+	docker run -it --rm -v ${PWD}:/app -w /app php:8.3-cli-alpine php -d error_reporting=-1 -d memory_limit=-1 bin/phpstan --ansi analyse
 
 phpunit:
-	docker run -it --rm -v ${PWD}:/app -w /app php:7.4-cli-alpine php -d error_reporting=-1 bin/phpunit --colors=always -c phpunit.xml
+	docker run -it --rm -v ${PWD}:/app -w /app php:8.3-cli-alpine php -d error_reporting=-1 bin/phpunit --colors=always -c phpunit.xml
 
 fmt-check:
-	docker run -it --rm -v ${PWD}:/app -w /app php:7.4-cli-alpine php bin/phpcs --standard=./ruleset.xml --extensions=php --tab-width=4 -sp ./src ./tests
+	docker run -it --rm -v ${PWD}:/app -w /app php:8.3-cli-alpine php bin/phpcs --standard=./ruleset.xml --extensions=php --tab-width=4 -sp ./src ./tests
 
 fmt:
-	docker run -it --rm -v ${PWD}:/app -w /app php:7.4-cli-alpine php bin/phpcbf --standard=./ruleset.xml --extensions=php --tab-width=4 -sp ./src ./tests
+	docker run -it --rm -v ${PWD}:/app -w /app php:8.3-cli-alpine php bin/phpcbf --standard=./ruleset.xml --extensions=php --tab-width=4 -sp ./src ./tests

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4|^8.0",
+    "php": ">=8.0",
     "ext-json": "*"
   },
   "suggest": {
@@ -22,11 +22,11 @@
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.0.2",
-    "phpstan/phpstan": "=1.8.2",
+    "phpstan/phpstan": "2.0",
     "phpunit/phpunit": "^9.4.2",
     "slevomat/coding-standard": "^6.4.1",
     "squizlabs/php_codesniffer": "^3.5.0",
-    "bonami/phpstan-collections": "^0.4.2"
+    "bonami/phpstan-collections": "dev-upgrade-to-phpstan2"
   },
   "config": {
     "bin-dir": "bin",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,16 +1,19 @@
 includes:
-	- phpstan.baseline.neon
-	- vendor/bonami/phpstan-collections/extension.neon
+    - phpstan.baseline.neon
+    - vendor/bonami/phpstan-collections/extension.neon
 parameters:
-	ignoreErrors:
-	universalObjectCratesClasses:
-		- stdClass
-		- DOMElement
-		- SimpleXMLElement
-	inferPrivatePropertyTypeFromConstructor: true
-	reportUnmatchedIgnoredErrors: false
-	level: 8
-	paths:
-		- src/
-		- tests/
-	tmpDir: /tmp/phpstan
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            identifier: function.alreadyNarrowedType
+    universalObjectCratesClasses:
+        - stdClass
+        - DOMElement
+        - SimpleXMLElement
+    inferPrivatePropertyTypeFromConstructor: true
+    reportUnmatchedIgnoredErrors: false
+    level: 8
+    paths:
+        - src/
+        - tests/
+    tmpDir: /tmp/phpstan

--- a/src/Bonami/Collection/Applicative1.php
+++ b/src/Bonami/Collection/Applicative1.php
@@ -68,6 +68,7 @@ trait Applicative1
     final public static function lift(callable $callable): callable
     {
         return static function (self ...$arguments) use ($callable): self {
+            // @phpstan-ignore-next-line
             return self::sequence($arguments)->map(static function ($args) use ($callable) {
                 return $callable(...$args);
             });

--- a/src/Bonami/Collection/ArrayList.php
+++ b/src/Bonami/Collection/ArrayList.php
@@ -204,8 +204,8 @@ class ArrayList implements Countable, IteratorAggregate, JsonSerializable
                 return $iterable->items;
             case $iterable instanceof Map:
                 return $iterable->values()->items;
-			default:
-				return iterator_to_array($iterable, false);
+            default:
+                return iterator_to_array($iterable, false);
         }
     }
 
@@ -908,7 +908,9 @@ class ArrayList implements Countable, IteratorAggregate, JsonSerializable
      * n = number of items in this list
      * m = number of items to remove.
      *
-     * @param iterable<T> $itemsToRemove
+     * @template T2
+     *
+     * @param iterable<T2> $itemsToRemove
      * @param bool|null $strictComparison
      *
      * @return static<T>
@@ -1001,7 +1003,9 @@ class ArrayList implements Countable, IteratorAggregate, JsonSerializable
      *
      * Complexity: o(n)
      *
-     * @param iterable<T> $items
+     * @template T2
+     *
+     * @param iterable<T2> $items
      *
      * @return static<T>
      */

--- a/src/Bonami/Collection/ArrayList.php
+++ b/src/Bonami/Collection/ArrayList.php
@@ -204,10 +204,8 @@ class ArrayList implements Countable, IteratorAggregate, JsonSerializable
                 return $iterable->items;
             case $iterable instanceof Map:
                 return $iterable->values()->items;
-            case $iterable instanceof Traversable:
-                return iterator_to_array($iterable, false);
-            default:
-                throw new NotImplementedException('Unimplemented iterable argument');
+			default:
+				return iterator_to_array($iterable, false);
         }
     }
 

--- a/src/Bonami/Collection/Either.php
+++ b/src/Bonami/Collection/Either.php
@@ -101,8 +101,6 @@ abstract class Either implements IHashable, IteratorAggregate
             /**
              * Consider calling getOrElse instead
              *
-             * @throws ValueIsNotPresentException
-             *
              * @return L
              */
             public function getLeftUnsafe()
@@ -144,9 +142,7 @@ abstract class Either implements IHashable, IteratorAggregate
                 return TrySafe::failure(new ValueIsNotPresentException());
             }
 
-            /** @return int|string */
-            /** @return int|string */
-            public function hashCode()
+            public function hashCode(): string
             {
                 $valueHash = $this->left instanceof IHashable
                     ? $this->left->hashCode()
@@ -268,8 +264,6 @@ abstract class Either implements IHashable, IteratorAggregate
             /**
              * Consider calling getOrElse instead
              *
-             * @throws ValueIsNotPresentException
-             *
              * @return V
              */
             public function getRightUnsafe()
@@ -299,8 +293,7 @@ abstract class Either implements IHashable, IteratorAggregate
                 return TrySafe::success($this->right);
             }
 
-            /** @return int|string */
-            public function hashCode()
+            public function hashCode(): string
             {
                 $valueHash = $this->right instanceof IHashable
                     ? $this->right->hashCode()

--- a/src/Bonami/Collection/LazyList.php
+++ b/src/Bonami/Collection/LazyList.php
@@ -386,7 +386,7 @@ class LazyList implements IteratorAggregate
          });
     }
 
-    /** @return Option<T> */
+    /** @return Option<T|null> */
     public function last(): Option
     {
          // No first item implies there is also no last item, thus we have to return none

--- a/src/Bonami/Collection/Map.php
+++ b/src/Bonami/Collection/Map.php
@@ -149,6 +149,7 @@ class Map implements Countable, IteratorAggregate
                 $stringKey = get_class($key) . ' keyhash:' . $keyHash;
                 break;
             case is_object($key) && (new ReflectionClass($key))->hasMethod('__toString'):
+                //@phpstan-ignore-next-line
                 $stringKey = (string)$key;
                 break;
             case is_object($key):
@@ -793,10 +794,10 @@ class Map implements Countable, IteratorAggregate
     public function getByKeys(iterable $keys)
     {
         $hashes = ArrayList::fromIterable($keys)
-            ->map(static function ($key) {
-                return hashKey($key);
-            })
-            ->filter(function ($keyHash) {
+            ->map(
+                /** @param K $key */
+                static fn($key) => hashKey($key)
+            )->filter(function ($keyHash) {
                 return array_key_exists($keyHash, $this->keys);
             });
 

--- a/src/Bonami/Collection/Map.php
+++ b/src/Bonami/Collection/Map.php
@@ -419,9 +419,6 @@ class Map implements Countable, IteratorAggregate
         $keys = array_replace($this->keys, $mergeMap->keys);
         $values = array_replace($this->values, $mergeMap->values);
 
-        assert($keys !== null);
-        assert($values !== null);
-
         $map->keys = $keys;
         $map->values = $values;
         return $map;

--- a/src/Bonami/Collection/Monad1.php
+++ b/src/Bonami/Collection/Monad1.php
@@ -20,7 +20,7 @@ trait Monad1
      * @param self<CurriedFunction<A, B>> $closure
      * @param self<A> $argument
      *
-     * @return self<B>
+     * @return self<mixed>
      */
     final public static function ap(self $closure, self $argument): self
     {

--- a/src/Bonami/Collection/Option.php
+++ b/src/Bonami/Collection/Option.php
@@ -134,8 +134,7 @@ abstract class Option implements IHashable, IteratorAggregate
                 return Either::left($left);
             }
 
-            /** @return int|string */
-            public function hashCode()
+            public function hashCode(): string
             {
                 return spl_object_hash($this); // There should be only one instance of none
             }
@@ -221,13 +220,11 @@ abstract class Option implements IHashable, IteratorAggregate
 
             public function exists(callable $predicate): bool
             {
-                return $predicate($this->value);
+                return $predicate($this->value, 1);
             }
 
             /**
              * Consider calling getOrElse instead
-             *
-             * @throws ValueIsNotPresentException
              *
              * @return V
              */
@@ -275,8 +272,7 @@ abstract class Option implements IHashable, IteratorAggregate
                 return Either::right($this->value);
             }
 
-            /** @return int|string */
-            public function hashCode()
+            public function hashCode(): string
             {
                 $valueHash = $this->value instanceof IHashable
                     ? $this->value->hashCode()
@@ -352,7 +348,7 @@ abstract class Option implements IHashable, IteratorAggregate
     abstract public function filter(callable $predicate): self;
 
     /**
-     * @param callable(T, int=): bool $predicate
+     * @param callable(T, int): bool $predicate
      *
      * @return bool
      */

--- a/src/Bonami/Collection/TrySafe.php
+++ b/src/Bonami/Collection/TrySafe.php
@@ -103,9 +103,13 @@ abstract class TrySafe implements IHashable, IteratorAggregate
             }
 
             /** @inheritDoc */
-            public function flatMap(callable $mapper): TrySafe
+            public function flatMap(callable|Throwable $mapper): TrySafe
             {
-                try {
+				if ($mapper instanceof Throwable) {
+					return self::failure($mapper);
+				}
+
+				try {
                     $trySafe = $mapper($this->value);
                 } catch (Throwable $failure) {
                     return self::failure($failure);
@@ -232,7 +236,7 @@ abstract class TrySafe implements IHashable, IteratorAggregate
                 return $this;
             }
 
-            public function flatMap(callable $mapper): TrySafe
+            public function flatMap(callable|Throwable $mapper): TrySafe
             {
                 return $this;
             }
@@ -367,14 +371,14 @@ abstract class TrySafe implements IHashable, IteratorAggregate
      */
     abstract public function map(callable $mapper): self;
 
-    /**
-     * @template B
-     *
-     * @param callable(T): self<B> $mapper
-     *
-     * @return self<B>
-     */
-    abstract public function flatMap(callable $mapper): self;
+	/**
+	 * @template B
+	 *
+	 * @param callable(mixed): B |Throwable $mapper
+	 *
+	 * @return self<B>
+	 */
+    abstract public function flatMap(callable|Throwable $mapper): self;
 
     /**
      * Executes $sideEffect if TrySafe is successful and ignores it otherwise

--- a/src/Bonami/Collection/TrySafe.php
+++ b/src/Bonami/Collection/TrySafe.php
@@ -105,11 +105,11 @@ abstract class TrySafe implements IHashable, IteratorAggregate
             /** @inheritDoc */
             public function flatMap(callable|Throwable $mapper): TrySafe
             {
-				if ($mapper instanceof Throwable) {
-					return self::failure($mapper);
-				}
+                if ($mapper instanceof Throwable) {
+                    return self::failure($mapper);
+                }
 
-				try {
+                try {
                     $trySafe = $mapper($this->value);
                 } catch (Throwable $failure) {
                     return self::failure($failure);
@@ -193,8 +193,7 @@ abstract class TrySafe implements IHashable, IteratorAggregate
                 return new ArrayIterator([$this->value]);
             }
 
-            /** @return int|string */
-            public function hashCode()
+            public function hashCode(): string
             {
                 $valueHash = $this->value instanceof IHashable
                     ? $this->value->hashCode()
@@ -272,7 +271,6 @@ abstract class TrySafe implements IHashable, IteratorAggregate
              */
             public function recoverWith(callable $callable): TrySafe
             {
-                /** @var callable(TrySafe<T>): TrySafe<T> $id */
                 $id = static function ($x) {
                     return $x;
                 };
@@ -341,8 +339,7 @@ abstract class TrySafe implements IHashable, IteratorAggregate
                 return new EmptyIterator();
             }
 
-            /** @return int|string */
-            public function hashCode()
+            public function hashCode(): string
             {
                 $failureHash = $this->failure instanceof IHashable
                     ? $this->failure->hashCode()
@@ -371,13 +368,13 @@ abstract class TrySafe implements IHashable, IteratorAggregate
      */
     abstract public function map(callable $mapper): self;
 
-	/**
-	 * @template B
-	 *
-	 * @param callable(mixed): B |Throwable $mapper
-	 *
-	 * @return self<B>
-	 */
+    /**
+     * @template B
+     *
+     * @param callable(mixed): B |Throwable $mapper
+     *
+     * @return self<B>
+     */
     abstract public function flatMap(callable|Throwable $mapper): self;
 
     /**

--- a/tests/Bonami/Collection/ArrayListTest.php
+++ b/tests/Bonami/Collection/ArrayListTest.php
@@ -189,7 +189,6 @@ class ArrayListTest extends TestCase
 
     public function testTraverse(): void
     {
-        /** @phpstan-var callable(int): ArrayList<int> $fillAForOdd */
         $fillAForOdd = static function (int $i): ArrayList {
             return $i % 2 === 0 ? ArrayList::of($i) : ArrayList::fromEmpty();
         };

--- a/tests/Bonami/Collection/CurriedFunctionTest.php
+++ b/tests/Bonami/Collection/CurriedFunctionTest.php
@@ -26,7 +26,7 @@ class CurriedFunctionTest extends TestCase
             return str_repeat(sprintf('%s %s,', $greeting, $name), $times);
         });
 
-        self::assertIsCallable($curried);
+        self::assertInstanceOf(CurriedFunction::class, $curried);
         self::assertIsCallable($curried('Hello'));
         self::assertIsCallable($curried('Hello')('World'));
         self::assertEquals('Hello World,Hello World,', $curried('Hello')('World')(2));
@@ -35,7 +35,9 @@ class CurriedFunctionTest extends TestCase
     public function testMap(): void
     {
         $greeter = CurriedFunction::of(static function (string $name) {
-            return sprintf('Hello %s', $name);
+            /** @var string $s */
+            $s = sprintf('Hello %s', $name);
+            return $s;
         });
         $countChars = CurriedFunction::of(static function (string $string): int {
             return strlen($string);

--- a/tests/Bonami/Collection/EitherTest.php
+++ b/tests/Bonami/Collection/EitherTest.php
@@ -90,11 +90,10 @@ class EitherTest extends TestCase
 
     public function testFlatMap(): void
     {
-        /** @phpstan-var callable(string): Either<string, string> */
-        $politeGreeter = static function (string $s): Either {
+		$politeGreeter = static function (string $s): Either {
             return Either::right(sprintf('Hello %s', $s));
         };
-        /** @phpstan-var callable(string): Either<string, string> */
+
         $failingGreeter = static function (string $s): Either {
             return Either::left('No manners');
         };

--- a/tests/Bonami/Collection/EitherTest.php
+++ b/tests/Bonami/Collection/EitherTest.php
@@ -90,7 +90,7 @@ class EitherTest extends TestCase
 
     public function testFlatMap(): void
     {
-		$politeGreeter = static function (string $s): Either {
+        $politeGreeter = static function (string $s): Either {
             return Either::right(sprintf('Hello %s', $s));
         };
 
@@ -114,11 +114,12 @@ class EitherTest extends TestCase
 
     public function testFlatMapLeft(): void
     {
-        /** @phpstan-var callable(string): Either<string, string> */
         $politeGreeter = static function (string $s): Either {
-            return Either::right(sprintf('Hello %s', $s));
+            /** @var string $s */
+            $s = sprintf('Hello %s', $s);
+            return Either::right($s);
         };
-        /** @phpstan-var callable(string): Either<string, string> */
+
         $failingGreeter = static function (string $s): Either {
             return Either::left('Fail');
         };
@@ -340,12 +341,10 @@ class EitherTest extends TestCase
 
         $numbersLowerThan10 = [1, 2, 3, 7, 9];
 
-        /** @phpstan-var callable(int): Either<string, int> */
         $wrapLowerThan10 = static function (int $int): Either {
             return $int < 10 ? Either::right($int) : Either::left('higher then ten');
         };
 
-        /** @phpstan-var callable(int): Either<string, int> */
         $wrapLowerThan9 = static function (int $int): Either {
             return $int < 9 ? Either::right($int) : Either::left('higher then nine');
         };

--- a/tests/Bonami/Collection/MapTest.php
+++ b/tests/Bonami/Collection/MapTest.php
@@ -202,7 +202,7 @@ class MapTest extends TestCase
     {
 
         $hashable = new class implements IHashable {
-            public function hashCode()
+            public function hashCode(): string
             {
                 return 'hash';
             }
@@ -419,7 +419,7 @@ class MapTest extends TestCase
         self::assertEquals([[1, 4], [3, 6], [12, 12], [4, 6], [5, 7]], $merged->getItems());
         try {
             $merged->getUnsafe(7);
-            self::assertTrue(false);
+            self::fail();
         } catch (InvalidArgumentException $e) {
             self::assertTrue(true);
         }

--- a/tests/Bonami/Collection/MapTest.php
+++ b/tests/Bonami/Collection/MapTest.php
@@ -11,6 +11,8 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function PHPUnit\Framework\assertEquals;
+
 class MapTest extends TestCase
 {
     public function testFromIterable(): void
@@ -421,7 +423,7 @@ class MapTest extends TestCase
             $merged->getUnsafe(7);
             self::fail();
         } catch (InvalidArgumentException $e) {
-            self::assertTrue(true);
+            assertEquals('Key (7) does not exist', $e->getMessage());
         }
     }
 
@@ -538,6 +540,7 @@ class MapTest extends TestCase
         $e = new stdClass();
         $map = new Map([
             [1, 'a'],
+            [2, 'b'],
             [3, 'c'],
             [4, 'd'],
             [5, $e],
@@ -548,6 +551,9 @@ class MapTest extends TestCase
             [7, false],
             [8, null],
         ]);
+
+        $map = $map->withoutKey(2);
+
         self::assertTrue($map->contains('a'));
         self::assertFalse($map->contains('b'));
         self::assertTrue($map->contains('c'));
@@ -566,8 +572,10 @@ class MapTest extends TestCase
         $five = new stdClass();
         $map = new Map([
             [1, 'a'],
+            [2, 'b'],
             [3, 'c'],
             [4, 'd'],
+            [5, ''],
             [$five, 'e'],
             [0, 'f'],
             [false, 'g'],
@@ -576,6 +584,9 @@ class MapTest extends TestCase
             [7, false],
             [8, null],
         ]);
+
+        $map = $map->withoutKeys([2, 5]);
+
         self::assertTrue($map->has(1));
         self::assertFalse($map->has(2));
         self::assertTrue($map->has(3));

--- a/tests/Bonami/Collection/OptionTest.php
+++ b/tests/Bonami/Collection/OptionTest.php
@@ -91,12 +91,11 @@ class OptionTest extends TestCase
 
     public function testFlatMap(): void
     {
-        /** @phpstan-var callable(string): Option<string> */
-        $mapperToSome = static function (string $s): Option {
+		$mapperToSome = static function (string $s): Option {
             return Option::some(sprintf('Hello %s', $s));
         };
-        /** @phpstan-var callable(string): Option<string> */
-        $mapperToNone = static function (string $s): Option {
+
+		$mapperToNone = static function (string $s): Option {
             return Option::none();
         };
 
@@ -373,12 +372,10 @@ class OptionTest extends TestCase
 
         $numbersLowerThan10 = [1, 2, 3, 7, 9];
 
-        /** @phpstan-var callable(int): Option<int> */
         $wrapLowerThan10 = static function (int $int): Option {
             return $int < 10 ? Option::some($int) : Option::none();
         };
 
-        /** @phpstan-var callable(int): Option<int> */
         $wrapLowerThan9 = static function (int $int): Option {
             return $int < 9 ? Option::some($int) : Option::none();
         };

--- a/tests/Bonami/Collection/OptionTest.php
+++ b/tests/Bonami/Collection/OptionTest.php
@@ -91,11 +91,11 @@ class OptionTest extends TestCase
 
     public function testFlatMap(): void
     {
-		$mapperToSome = static function (string $s): Option {
+        $mapperToSome = static function (string $s): Option {
             return Option::some(sprintf('Hello %s', $s));
         };
 
-		$mapperToNone = static function (string $s): Option {
+        $mapperToNone = static function (string $s): Option {
             return Option::none();
         };
 

--- a/tests/Bonami/Collection/TrySafeTest.php
+++ b/tests/Bonami/Collection/TrySafeTest.php
@@ -142,7 +142,7 @@ class TrySafeTest extends TestCase
 
     public function testFlatMap(): void
     {
-		$mapperToSuccess = static function (string $s): TrySafe {
+        $mapperToSuccess = static function (string $s): TrySafe {
             return TrySafe::success(sprintf('Hello %s', $s));
         };
 

--- a/tests/Bonami/Collection/TrySafeTest.php
+++ b/tests/Bonami/Collection/TrySafeTest.php
@@ -142,15 +142,14 @@ class TrySafeTest extends TestCase
 
     public function testFlatMap(): void
     {
-        /** @phpstan-var callable(string): TrySafe<string> */
-        $mapperToSuccess = static function (string $s): TrySafe {
+		$mapperToSuccess = static function (string $s): TrySafe {
             return TrySafe::success(sprintf('Hello %s', $s));
         };
-        /** @phpstan-var callable(string): TrySafe<string> */
+
         $mapperToFailure = function (string $s): TrySafe {
             return $this->createFailure();
         };
-        /** @phpstan-var callable(string): TrySafe<string> */
+
         $mapperThatThrows = static function () {
             throw new Exception();
         };
@@ -234,7 +233,7 @@ class TrySafeTest extends TestCase
             throw $exceptionThatRecoveryThrows;
         };
         $exceptionThatRecoveryWraps = new Exception();
-        /** @var callable(Throwable): TrySafe<int> $wrap */
+
         $wrap = static function (Throwable $failure) use ($exceptionThatRecoveryWraps): TrySafe {
             return TrySafe::failure($exceptionThatRecoveryWraps);
         };
@@ -279,7 +278,7 @@ class TrySafeTest extends TestCase
             throw $exceptionThatRecoveryThrows;
         };
         $exceptionThatRecoveryWraps = new Exception();
-        /** @var callable(Throwable): TrySafe<int> $wrap */
+
         $wrap = static function (Throwable $failure) use ($exceptionThatRecoveryWraps) {
             return TrySafe::failure($exceptionThatRecoveryWraps);
         };
@@ -468,7 +467,7 @@ class TrySafeTest extends TestCase
     private function createHashableException(): Throwable
     {
         return new class extends Exception implements IHashable {
-            public function hashCode()
+            public function hashCode(): string
             {
                 return self::class;
             }


### PR DESCRIPTION
Updated the minimum PHP version requirement to 8.0 in `composer.json` and upgraded `phpstan` to version 2.0. Modified the Docker configuration in the `Makefile` to use PHP 8.3 for relevant tasks. These changes ensure compatibility with newer PHP features and library versions.